### PR TITLE
fix: Ability to match UPPERCASE extensions

### DIFF
--- a/heic2jpg.sh
+++ b/heic2jpg.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 src=$1
-size=$(find $src -type f | grep heic | wc -l)
+size=$(find $src -type f | grep -i '\.heic$' | wc -l)
 cnt=0
 
-for i in $(find $src -type f | grep heic)
+for i in $(find $src -type f | grep -i '\.heic$')
 do
-    ((cnt=cnt+1))
-	target=$(echo $i | sed 's/heic$/jpg/')
+	((cnt=cnt+1))
+	target=$(echo $i | sed 's/heic$/jpg/i')
 	printf "$i convert to $target\n"
 	/usr/bin/convert $i $target
 	printf " [$cnt/$size]\r"


### PR DESCRIPTION
I've tried this container, and I couldn't convert files when their extensions are UPPERCASED. This change fixes it.